### PR TITLE
feat: remove IDs from BankDetails and Address

### DIFF
--- a/apispec.yaml
+++ b/apispec.yaml
@@ -505,7 +505,6 @@ components:
         - houseNumber
         - zipCode
         - city
-        - id
       properties:
         street:
           type: string
@@ -524,17 +523,12 @@ components:
           type: string
           pattern: "^[A-Z][a-z]*$"
           example: "Musterstadt"
-        id:
-          type: string
-          format: uuid
-          example: "123e4567-e89b-12d3-a456-426614174000"
     BankDetails:
       type: object
       required:
         - iban
         - bic
         - name
-        - id
       properties:
         iban:
           type: string
@@ -548,10 +542,6 @@ components:
           type: string
           pattern: "^[A-Z][a-z]*$"
           example: "Max Mustermann"
-        id:
-          type: string
-          format: uuid
-          example: "123e4567-e89b-12d3-a456-426614174000"
     EmployeeReq:
       type: object
       required:


### PR DESCRIPTION
Mit Felix ist abgesprochen, dass die IDs der BankDetails und Address Objekte entfernt werden können.

@marcmarder