### PR TITLE
fix(api): correct IBAN regex

### DIFF
--- a/apispec.yaml
+++ b/apispec.yaml
@@ -566,7 +566,7 @@ components:
       properties:
         iban:
           type: string
-          pattern: "^[A-Z]{2}[0-9]{2}[A-Z]{4}[0-9]{7}([A-Z0-9]{0,16})?$"
+          pattern: "^[A-Z]{2}[0-9]{2}(?:[ ]?[0-9]{4}){4}(?:[ ]?[0-9]{1,2})?$"
           example: "DE89 3704 0044 0532 0130 00"
         bic:
           type: string


### PR DESCRIPTION
Das alte Pattern für IBANs macht keinen Sinn.
Das neue ist hier her: https://stackoverflow.com/questions/44656264/iban-regex-design